### PR TITLE
data: rat_fetch groups + nested unzip + relaxed convert; tests: groups + quiet run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,7 @@ cython_debug/
 
 #Mac DS Store files
 .DS_Store
+
+# Data download
+rat_data/
+rat_data_nifti/

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ scipy
 dbdicom
 pydicom<3               # needed by dicom2nifti & dbdicom (keep <3 for compatibility)
 dicom2nifti==2.3.4      # DICOM ➜ NIfTI conversion utility
+pytest

--- a/src/miblab/data.py
+++ b/src/miblab/data.py
@@ -584,7 +584,8 @@ def _relax_dicom2nifti_validators() -> None:
                "disable_validate_dimensions",
                "disable_validate_dimension",
                "disable_validate_slicecount",
-               "disable_validate_slice_count",):
+               "disable_validate_slice_count",
+               "disable_validate_slice_direction",):
         if hasattr(_dset, fn):
             getattr(_dset, fn)()
 


### PR DESCRIPTION
**Summary**

Adds group-aware downloads, safer unzip/convert, and targeted smoke tests for TRISTAN rat datasets.

**Changes**

- **`rat_fetch`**
  - Accepts group tokens: `rifampicin_effect_size`, `six_compound`, `field_strength`, `chronic`.
  - Updates DOI to `17178063`.
  - Recursive unzip with skips for `__MACOSX/` and `._*` artifacts.
  - Converts only when ≥ 3 `.dcm` slices.
  - Relaxes dicom2nifti validators (`orthogonal`, `sliceincrement`/`slice_increment`, `dimensions`/`dimension`, `slicecount`/`slice_count`).
  - Return value unchanged (list of downloaded ZIP paths).

- **`osf_fetch`**
  - Guarded behind `miblab[data]` (ensures `osfclient`, `requests`, `tqdm`).
  - Recursively downloads folders with optional auto-unzip.

- **Tests** (`tests/test_rat_fetch.py`)
  - Adds group smoke tests; some marked `slow`; auto-`skipif` when `dicom2nifti` missing.
  - Network gating (DNS + HEAD); transient 50x/connection errors → `pytest.skip`.
  - Quieter output (disable `tqdm`, silence noisy deprecations).
  - `__main__` block for manual run.